### PR TITLE
docs(phase-1): add project analysis, audit, plan, and changelog

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,89 @@
+# AUDIT_REPORT.md — Zero Hunger
+
+> Production-readiness audit. Severity: 🔴 Critical · 🟠 High · 🟡 Medium · 🔵 Low/Polish
+> Date: 2026-06-02 · Baseline: backend `tsc` clean, frontend `tsc` + `vite build` clean.
+
+---
+
+## 🔴 Critical (break functionality or expose the platform)
+
+### C1 — JWT payload/claim mismatch breaks all authenticated `req.user.id` routes
+- `authController.login` signs `{ id: user._id, role }` ([authController.ts:75](Backend/src/controllers/authController.ts#L75)).
+- `authMiddleware` decodes as `{ _id, role }` and sets `req.user = { id: decoded._id, role }` ([authMiddleware.ts:28](Backend/src/middlewares/authMiddleware.ts#L28)).
+- Result: `req.user.id === undefined` on every protected request. Any controller that queries by `req.user.id` (donor stats/donations/notifications, NGO stats/volunteers/claims, volunteer tasks, profile update, `getOwnUser`) operates on `undefined` → wrong/empty results or cast errors.
+- **Fix:** make the signed payload and the decoded shape agree on one claim name (`id`), and type the decode accordingly.
+
+### C2 — Live secrets committed to git
+- `Backend/.env` (Mongo Atlas URI **with password**, `JWT_SECRET=supersecretkey`, Gmail `EMAIL_PASS`, `IMGBB_KEY`) and `Frontend/.env` are tracked (`git ls-files` confirms).
+- **Fix:** `git rm --cached` both, add to ignore (already ignored going forward), add `.env.example`, document mandatory credential rotation. (No history purge per decision.)
+
+### C3 — Weak/committed JWT secret
+- `JWT_SECRET=supersecretkey` — trivially guessable and public. Anyone can forge admin tokens.
+- **Fix:** require a strong secret from env, fail fast if missing/weak; rotate.
+
+### C4 — Unauthenticated notification creation + broken field names
+- `POST /api/notifications` (`sendNotification`) has **no auth** and anyone can spam-create notifications/emails ([notificationRoutes.ts](Backend/src/routes/notificationRoutes.ts)).
+- It writes `receiver_id` / reads `receiver_id`, but the schema field is `recipientId` ([notificationController.ts:7,26](Backend/src/controllers/notificationController.ts#L7)). These notifications never associate to a user.
+- **Fix:** authenticate, restrict, and align field names — or remove the endpoint (per-role notification routes already cover the app).
+
+## 🟠 High
+
+### H1 — CORS hardcoded to localhost
+- `server.ts` sets `origin: 'http://localhost:5173'` ([server.ts:26](Backend/src/server.ts#L26)); production frontend will be blocked. **Fix:** drive from `FRONTEND_URL`/allowlist env.
+
+### H2 — Cookie `sameSite:'none'` without `secure` in dev
+- Login cookie uses `sameSite:'none'` with `secure` only in prod ([authController.ts:81](Backend/src/controllers/authController.ts#L81)). `none` without `secure` is rejected by modern browsers. The app actually relies on the **Bearer token in localStorage**, so the cookie is dead weight + XSS-exfiltration surface. **Fix:** make cookie config coherent or drop it; pick one auth transport.
+
+### H3 — No global error handler / unhandled async rejections
+- `addFood`, `acceptFood`, `assignVolunteer`, `updateStatus` ([foodController.ts](Backend/src/controllers/foodController.ts)) have **no try/catch** → unhandled promise rejections crash or hang requests. No Express error middleware exists.
+
+### H4 — No input validation layer
+- Bodies are trusted directly. No schema validation (e.g., zod/express-validator). Status strings, IDs, quantities unvalidated in several handlers.
+
+### H5 — No rate limiting / brute-force protection on auth
+- `login`, `forgot-password`, `register`, `contact` are unthrottled → credential stuffing & email-bomb risk.
+
+### H6 — No security headers (helmet) and `error` objects leaked to clients
+- Many handlers return `error: error.message` (and sometimes the raw `error` object) to the client, leaking internals.
+
+### H7 — Frontend dead routes
+- App defines `/auth` but code navigates to `/login` (signOut, PrivateRoute redirect target, Listings) and `/my-claims` (Listings) — neither route exists; users land on catch-all `/`. ([App.tsx](Frontend/src/components/../App.tsx), [AuthContext.tsx:108](Frontend/src/contexts/AuthContext.tsx#L108), [Listings.tsx:89](Frontend/src/components/Listings.tsx#L89))
+
+### H8 — Bearer token in `localStorage`
+- Susceptible to XSS token theft. Acceptable for MVP but should be documented; mitigate with strict CSP / input sanitization, or move to httpOnly cookie consistently.
+
+## 🟡 Medium
+
+- **M1 — Inconsistent HTTP client:** `utils/axios.ts` instance (with interceptors) exists but contexts mostly call bare `axios` with manual headers → no centralized 401 handling, duplicated logic.
+- **M2 — Two toast libraries** (`react-toastify` + `react-hot-toast`) bundled; pick one.
+- **M3 — NGO↔volunteer linkage by `organization_name` string** instead of `ngoId` ObjectId ([ngoController.ts:57](Backend/src/controllers/ngoController.ts#L57)) — fragile (rename breaks links, name collisions).
+- **M4 — `Food` schema vs `IFood` interface drift** ([Food.ts](Backend/src/models/Food.ts)) — interface fields (`foodLocation`, `expiryDate`) don't exist in schema; misleading types.
+- **M5 — Legacy duplicate food endpoints** (`/api/food/*` `addFood/acceptFood/...`) overlap NGO/volunteer controllers and contain bugs (`userId` vs `donorId`); likely unused → remove.
+- **M6 — `completedOrders` never incremented**; volunteer `rating` increments by 0.5 with no cap/ratings model.
+- **M7 — No pagination** on admin/donation/notification lists → scaling problem.
+- **M8 — `console.log` debugging left in** controllers (getOwnUser, deleteVolunteer, contact).
+- **M9 — Socket.IO dependency unused**; notifications poll every 10s per role context (extra load).
+- **M10 — `ResetToken` model appears unused** (reset uses User doc fields).
+- **M11 — Frontend reads `user._id` in places but login response/`getOwnUser` shapes vary**; ensure consistent user shape.
+
+## 🔵 Low / Polish
+
+- **L1 — `index.html` title** = "Vite + React + TS"; favicon is default Vite svg.
+- **L2 — Frontend package name** = "vite-react-typescript-starter".
+- **L3 — Large single JS bundle** (429 KB) — no code-splitting/manualChunks.
+- **L4 — `Frontend/.env` has a leading space** before `VITE_API_BASE_URL`.
+- **L5 — `@types/date-fns` / `@types/react-toastify`** are stub/deprecated types; libs ship their own.
+- **L6 — Commented-out dead code** across auth middleware, axios, volunteer controller.
+- **L7 — No `.dockerignore`/Dockerfile**, no `/health` endpoint for Render health checks.
+- **L8 — No automated tests** (CI only typechecks/builds).
+
+---
+
+## Build / Tooling baseline (verified Phase 1)
+| Check | Result |
+|---|---|
+| Backend `tsc --noEmit` | ✅ pass |
+| Frontend `tsc --noEmit` | ✅ pass |
+| Frontend `vite build` | ✅ pass (1 chunk, 429 KB) |
+| Tests | ❌ none |
+| Lint | configured (eslint) — not run in audit |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the Zero Hunger platform are documented here.
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/). The project uses phased,
+production-hardening releases (`feature/phase-xx-*`).
+
+## [Unreleased]
+
+### Phase 1 — Analysis & Documentation (2026-06-02)
+- Added `PROJECT_MEMORY.md` — single source of truth (architecture, flows, DB, API, decisions).
+- Added `AUDIT_REPORT.md` — prioritized production-readiness audit (4 critical, 8 high, 11 medium, 8 low).
+- Added `IMPLEMENTATION_PLAN.md` — 10-phase plan to Render production.
+- Added `CHANGELOG.md`.
+- Established build baseline: backend `tsc` ✅, frontend `tsc` ✅, `vite build` ✅.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,68 @@
+# IMPLEMENTATION_PLAN.md — Zero Hunger
+
+> Phased plan to take the platform to production on Render. Each phase = one `feature/phase-xx-*` branch, committed and reported.
+> Cross-references issue IDs in [AUDIT_REPORT.md](AUDIT_REPORT.md).
+
+---
+
+## Phase 1 — Analysis & docs ✅ (this commit)
+- Full repo read; `PROJECT_MEMORY.md`, `AUDIT_REPORT.md`, `IMPLEMENTATION_PLAN.md`, `CHANGELOG.md`.
+- Establish build baseline (backend tsc, frontend tsc + build — all green).
+
+## Phase 2 — Critical fixes  `feature/phase-02-critical-fixes`
+- **C1** Fix JWT id mismatch (align payload + middleware on `id`).
+- **C2** `git rm --cached` both `.env`; add `Backend/.env.example`, `Frontend/.env.example`.
+- **C3** Enforce strong `JWT_SECRET` from env (fail fast); placeholder rotated in examples.
+- **C4** Secure/align or remove `/api/notifications` (`recipientId`, add auth).
+- **H7** Add real `/auth` redirects; fix `/login` & `/my-claims` navigations.
+- Smoke: typecheck both, build frontend.
+
+## Phase 3 — Backend reliability  `feature/phase-03-backend`
+- **H3** Add async wrapper + global error-handling middleware; wrap all controllers.
+- **H4** Add validation (zod) on auth, donation, status-update, volunteer, contact bodies.
+- **H6** Stop leaking raw errors; standardized JSON error shape; structured logging.
+- **M4** Reconcile `Food` schema/interface. **M3** add real `ngoId` linkage (keep org_name fallback for migration). **M5/M10** remove dead food endpoints + unused ResetToken (if confirmed). **M8** remove debug logs.
+- Centralize env config module with validation; `connectDB` ret/timeout + don't `process.exit` in serverless contexts.
+
+## Phase 4 — Frontend quality  `feature/phase-04-frontend`
+- **M1** Route all API calls through the shared axios instance (baseURL + interceptors + 401 handling).
+- **M2** Consolidate to one toast library.
+- Fix user-shape consistency (`_id`), loading/empty/error states on dashboards & listings.
+- **L1/L2/L4** Branding (title, favicon, package name), fix `.env` whitespace.
+- Route guards: redirect unauthenticated to `/auth`; post-login role routing already present.
+
+## Phase 5 — High-value features  `feature/phase-05-features`
+- **Socket.IO real-time notifications** (server integration + per-user rooms + client hook), replacing/augmenting 10s polling (M9).
+- Notification "mark all read" + unread badge; consistent notification model across roles.
+- Donation lifecycle polish (volunteer pickup confirmation, donor cancel guards).
+
+## Phase 6 — Security hardening  `feature/phase-06-security`
+- **H1** CORS allowlist from env. **H2/H8** coherent auth transport + document.
+- **H5** Rate limiting (auth, contact, global). **H6** `helmet`, payload size limits.
+- Input sanitization / NoSQL-injection guard (`express-mongo-sanitize` or manual). Secrets rotation doc.
+
+## Phase 7 — Performance  `feature/phase-07-performance`
+- **M7** Pagination on admin/donation/notification lists. DB indexes (status, donorId, ngoId, volunteerId, recipientId).
+- **L3** Frontend code-splitting (route-level lazy, manualChunks). gzip/asset caching.
+- Reduce notification polling once sockets land.
+
+## Phase 8 — Render deployment  `feature/phase-08-render`
+- `render.yaml` (Backend Web Service + Frontend Static Site).
+- `/health` endpoint; production build/start commands; env var documentation.
+- Replace `vercel.json`; ensure Socket.IO works on persistent web service; SPA rewrite for static site.
+
+## Phase 9 — Testing & QA  `feature/phase-09-testing`
+- Backend unit/integration tests (auth, donation flow, notifications) with an in-memory/CI Mongo.
+- Frontend smoke/component tests for critical flows. Wire into CI (`ci.yml`).
+- Manual QA pass of all four role flows.
+
+## Phase 10 — Documentation  `feature/phase-10-docs`
+- Finalize: `README.md`, `SYSTEM_ARCHITECTURE.md`, `API_DOCUMENTATION.md`, `DATABASE_DOCUMENTATION.md`, `DEPLOYMENT_GUIDE.md`, `SECURITY_GUIDE.md`, `CONTRIBUTING.md`.
+- Ensure docs reflect final implementation; update PROJECT_MEMORY + CHANGELOG.
+
+---
+
+### Working rules
+- Update `PROJECT_MEMORY.md` + `CHANGELOG.md` each phase.
+- Per phase report: **Summary · Risks · Files changed · Tests performed**.
+- Keep typecheck + frontend build green at every phase boundary.

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,0 +1,203 @@
+# PROJECT_MEMORY.md — Zero Hunger
+
+> Single source of truth for the Zero Hunger platform. Updated continuously as work progresses.
+> Last updated: 2026-06-02 (Phase 1 — initial analysis)
+
+---
+
+## 1. Product Purpose
+
+**Zero Hunger** is a food-rescue / food-redistribution platform that connects four kinds of users to reduce food waste and fight hunger:
+
+- **Donors** — restaurants, businesses, or individuals who post surplus food donations.
+- **NGOs** — organizations that claim donations and coordinate distribution.
+- **Volunteers** — people affiliated with an NGO who pick up and deliver claimed food.
+- **Admins** — platform operators who approve users and oversee donations.
+
+### Core value loop
+1. Donor posts a food donation (with quantity, expiry, pickup window, location, photo).
+2. All NGOs are notified; an NGO **claims** the donation.
+3. NGO **assigns a volunteer** to handle pickup/delivery.
+4. Volunteer updates task status (`in_progress` → `completed`).
+5. Donor is notified at each milestone; volunteer earns a rating bump on completion.
+
+---
+
+## 2. Architecture Summary
+
+Monorepo with two apps:
+
+```
+Zero-Hunger/
+├── Backend/   → Node + Express + TypeScript REST API, MongoDB (Mongoose)
+├── Frontend/  → React 18 + TypeScript + Vite + Tailwind + MUI
+├── .github/workflows/ci.yml  → typecheck + frontend build
+```
+
+### Backend stack
+- **Runtime:** Node, Express 4, TypeScript (commonjs, target ES2020)
+- **DB:** MongoDB Atlas via Mongoose 7
+- **Auth:** JWT (Bearer header), bcrypt password hashing, httpOnly cookie also set on login
+- **Email:** Nodemailer (Gmail service) — confirmation, approval, reset, contact, volunteer onboarding
+- **Image upload:** ImgBB API (base64) via multer memory storage
+- **Real-time:** `socket.io` is a dependency but **NOT wired in** (server uses plain `app.listen`). Frontend currently **polls** notifications every 10s.
+- **Build:** `tsc` → `dist/`, start `node dist/server.js`
+- **Deploy (current):** `vercel.json` (serverless) — to be replaced with Render.
+
+### Frontend stack
+- **Framework:** React 18 + Vite 5 + TypeScript
+- **Routing:** react-router-dom v6
+- **State:** React Context per role (Auth, Admin, Donor, NGO, Volunteer, Food)
+- **HTTP:** axios (a configured instance in `utils/axios.ts` exists, but most contexts call `axios` directly with manual headers)
+- **UI:** Tailwind CSS + MUI + lucide-react icons; toasts via both `react-toastify` and `react-hot-toast`
+- **Auth storage:** JWT + user JSON in `localStorage`
+
+---
+
+## 3. User & Admin Flows
+
+### Registration / Approval
+- Donor/NGO/Volunteer register → account created with `isApproved: false`.
+- Confirmation email sent.
+- **Admin approves** the user (`PUT /api/admin/user-status/update`) → approval email sent.
+- Login is **blocked** until `isApproved === true` (403 otherwise).
+- Volunteers can alternatively be **created directly by an NGO** (auto-approved, random password emailed).
+
+### Donor flow
+- Create donation (multipart, optional image) → all NGOs notified.
+- View own donations + stats (total / pending / completed).
+- Delete or update status of own donations.
+- Receive notifications (claimed, completed).
+
+### NGO flow
+- View available donations (via `/api/food/available`), claim them.
+- View claimed foods, assign a volunteer, update food status, delete claimed food.
+- Manage volunteers (add / update / delete) scoped by `organization_name`.
+- Stats: volunteers, completed, pending. Notifications.
+
+### Volunteer flow
+- View assigned tasks + stats (available / in_progress / completed).
+- Update task status; NGO + donor notified on progress/completion; volunteer rating += 0.5 on completion.
+- Notifications.
+
+### Admin flow
+- Dashboard stats (counts of NGOs / donors / volunteers / donations + user list).
+- Approve users, delete users, view & delete all food donations.
+- `PUT /api/admin/settings` is a placeholder (no-op).
+
+---
+
+## 4. Database Structure (Mongoose models)
+
+### User (`models/User.ts`)
+| field | type | notes |
+|---|---|---|
+| name | String (req) | |
+| email | String (req, unique, regex) | |
+| password | String (req) | bcrypt-hashed via pre-save hook |
+| role | enum donor/ngo/volunteer/admin (req) | |
+| organization_name | String | used to link NGO↔volunteers |
+| contact_number | String | |
+| resetPasswordToken / resetPasswordExpires | String / Date | sha256 hash + 1h expiry |
+| status | enum Active/Inactive (def Active) | |
+| completedOrders | Number (def 0) | not actually incremented anywhere |
+| joinedDate | Date | |
+| isApproved | Boolean (def false) | gates login |
+| ngoId | ObjectId→User | set on volunteer (link is also done by org_name string — inconsistent) |
+| rating | Number (def 0) | volunteer rating |
+| timestamps | | createdAt/updatedAt |
+
+### Food (`models/Food.ts`)
+donorId, title, description, quantity, unit, expiry_time (Date), pickup_window_start/end (String), status (available/in_progress/assigned/completed, def available), ngoId, acceptance_time, volunteerId, delivered_time, pickup_location, temperature_requirements, contact_number, dietary_info, createdAt, img.
+> Note: the `IFood` TS interface and the actual schema **diverge** (interface lists fields like `foodLocation`/`expiryDate` not in schema).
+
+### Notification (`models/Notification.ts`)
+recipientId (→User, req), message (req), taskId (→Food, req), read (def false), createdAt.
+> Note: `notificationController.ts` writes/reads `receiver_id` — **field-name mismatch** with schema's `recipientId` (those notifications are broken).
+
+### ResetToken (`models/ResetToken.ts`)
+Present but reset flow stores token on the User doc instead — model likely unused. (To verify.)
+
+---
+
+## 5. API Structure
+
+Base: `/api`
+
+### `/api/auth`
+- `POST /register`
+- `POST /login`
+- `POST /forgot-password`
+- `POST /reset-password/:token`
+- `GET  /org-names`
+- `PUT  /update-profile` (auth)
+- `GET  /me` (auth)
+
+### `/api/admin` (admin only)
+- `GET /dashboard-stats`, `GET /food-donations`
+- `PUT /user-status/update`, `DELETE /users/:userId`
+- `DELETE /food-donations/:donationId`
+- `PUT /settings` (placeholder no-op)
+
+### `/api/donor` (mostly donor; some shared)
+- `POST /donate` (donor, multipart img)
+- `GET /stats`, `GET /my-donations` (donor/volunteer/ngo/admin)
+- `DELETE /donate/:id` (donor)
+- `PUT /donation/:id/status` (donor)
+- `GET /Notifications` (donor/ngo/volunteer/admin)  ← capital N
+- `PUT /notifications/:notificationId/read` (donor/ngo)
+
+### `/api/ngo` (ngo only)
+- `GET /volunteers`, `POST /claim/food`, `GET /claimed/foods`, `GET /stats`
+- `POST /assign-volunteer`, `DELETE /volunteers/:id`, `PUT /volunteers/:id`, `POST /volunteers`
+- `PATCH /food/:id/status`, `DELETE /claimed-food/:id`
+- `GET /notifications`, `PATCH /notifications/:notificationId/read`
+
+### `/api/volunteer` (volunteer only)
+- `GET /stats`, `GET /tasks`, `PATCH /tasks/:taskId/status`
+- `GET /notifications`, `PATCH /notifications/:notificationId/read`
+
+### `/api/food`
+- `POST /` (donor) — `addFood` (legacy, sets `userId` not `donorId` — buggy/unused)
+- `GET /available` — public list of available donations
+- `PUT /accept/:id` (ngo), `PUT /assign/:id` (ngo), `PUT /status/:id` (volunteer) — legacy duplicate of ngo/volunteer controllers
+
+### `/api/contact`
+- `POST /` — contact form → email
+
+### `/api/notifications`
+- `POST /` (no auth!) — `sendNotification` (writes wrong field, no auth guard)
+- `GET /` (auth) — `getNotifications` (reads wrong field)
+
+> **Notification endpoints are fragmented**: donor/ngo/volunteer each have their own. The `/api/notifications` controller is broken (field mismatch) and `POST` is unauthenticated.
+
+---
+
+## 6. Known Issues (see AUDIT_REPORT.md for full list)
+
+Top criticals discovered in Phase 1:
+1. **JWT id mismatch** — login signs `{id}`, middleware reads `decoded._id` → `req.user.id` is `undefined`. Breaks every `req.user.id`-dependent route.
+2. **Secrets committed** — `Backend/.env` & `Frontend/.env` are git-tracked with live Mongo/JWT/Gmail/ImgBB credentials.
+3. **Dead routes** — frontend navigates to `/login` and `/my-claims` which don't exist (only `/auth`).
+4. **Notification field mismatch** — `notificationController` uses `receiver_id` vs schema `recipientId`.
+5. **CORS hardcoded** to `http://localhost:5173`; cookie `sameSite:'none'` without `secure` in dev.
+6. **No global error handler, no input validation library, no rate limiting, no helmet.**
+
+---
+
+## 7. Decisions Made
+
+- **Secrets:** untrack `.env`, add `.env.example`, document rotation in SECURITY_GUIDE (no history rewrite).
+- **Deployment:** Render, two services — Backend Web Service + Frontend Static Site, via `render.yaml`.
+- **Real-time:** wire up Socket.IO properly for live notifications (replaces/augments 10s polling).
+- **Workflow:** autonomous through all 10 phases, commit per phase on `feature/phase-xx-*` branches, report after each.
+
+---
+
+## 8. Completed Work
+
+- _Phase 1 (in progress):_ full repo analysis; PROJECT_MEMORY, AUDIT_REPORT, IMPLEMENTATION_PLAN created.
+
+## 9. Pending Work
+
+- Phases 2–10 per IMPLEMENTATION_PLAN.md.


### PR DESCRIPTION
Phase 1 of production-hardening. Adds the four living documents that drive the remaining phases:

- PROJECT_MEMORY.md  — single source of truth (architecture, user/admin flows, DB models, API surface, decisions).
- AUDIT_REPORT.md    — prioritized findings: 4 critical (JWT id mismatch,
  committed secrets, weak JWT secret, unauthenticated/broken notifications),
  8 high, 11 medium, 8 low.
- IMPLEMENTATION_PLAN.md — 10-phase roadmap to Render production.
- CHANGELOG.md

No source changes. Build baseline verified: backend tsc, frontend tsc, and vite build all pass.