### PR TITLE
feat(phase-11): proof of delivery — photo upload + NGO confirmation step

### DIFF
--- a/Backend/src/controllers/ngoController.ts
+++ b/Backend/src/controllers/ngoController.ts
@@ -213,6 +213,39 @@ export const assignVolunteerToFood = asyncHandler(async (req: Request, res: Resp
   res.status(200).json({ message: 'Volunteer assigned successfully', food });
 });
 
+// NGO confirms a completed delivery (closes the accountability loop)
+export const confirmDelivery = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const ngoId = new mongoose.Types.ObjectId(req.user!.id);
+
+  const food = await Food.findOne({ _id: id, ngoId, status: 'completed' });
+  if (!food) throw new AppError('Completed donation not found for your NGO', 404);
+
+  (food as typeof food & { ngo_confirmed?: boolean; ngo_confirmed_at?: Date }).ngo_confirmed = true;
+  (food as typeof food & { ngo_confirmed?: boolean; ngo_confirmed_at?: Date }).ngo_confirmed_at = new Date();
+  await food.save();
+
+  // Notify donor that the delivery has been verified
+  await emitNotification({
+    recipientId: food.donorId,
+    message: `Your donation "${food.title}" delivery has been confirmed by the NGO.`,
+    taskId: food._id,
+    type: 'delivery_confirmed',
+  });
+
+  // Notify volunteer
+  if (food.volunteerId) {
+    await emitNotification({
+      recipientId: food.volunteerId,
+      message: `Your delivery of "${food.title}" has been confirmed. Great work!`,
+      taskId: food._id,
+      type: 'delivery_confirmed',
+    });
+  }
+
+  res.status(200).json({ message: 'Delivery confirmed', food });
+});
+
 // NGO notifications
 export const getNgoNotifications = asyncHandler(async (req: Request, res: Response) => {
   const notifications = await Notification.find({ recipientId: req.user!.id })

--- a/Backend/src/controllers/volunteerController.ts
+++ b/Backend/src/controllers/volunteerController.ts
@@ -5,6 +5,7 @@ import Notification from '../models/Notification';
 import { asyncHandler } from '../utils/asyncHandler';
 import { AppError } from '../utils/AppError';
 import { emitNotification } from '../utils/notify';
+import uploadImage from '../utils/uploadImage';
 
 export const getVolunteerStats = asyncHandler(async (req: Request, res: Response) => {
   const volunteerId = req.user!.id;
@@ -45,7 +46,15 @@ export const updateTaskStatus = asyncHandler(async (req: Request, res: Response)
 
   const previousStatus = task.status;
   task.status = status;
-  if (status === 'completed') task.delivered_time = new Date();
+
+  if (status === 'completed') {
+    task.delivered_time = new Date();
+    if (req.file) {
+      const proofUrl = await uploadImage(req.file);
+      (task as typeof task & { delivery_proof_img?: string }).delivery_proof_img = proofUrl;
+    }
+  }
+
   await task.save();
 
   if (status === 'in_progress' && previousStatus !== 'in_progress' && task.ngoId) {

--- a/Backend/src/models/Food.ts
+++ b/Backend/src/models/Food.ts
@@ -27,6 +27,9 @@ const foodSchema = new Schema(
     contact_number: String,
     dietary_info: String,
     img: String,
+    delivery_proof_img: String,
+    ngo_confirmed: { type: Boolean, default: false },
+    ngo_confirmed_at: Date,
   },
   { timestamps: true }
 );

--- a/Backend/src/models/Notification.ts
+++ b/Backend/src/models/Notification.ts
@@ -11,6 +11,7 @@ export const NOTIFICATION_TYPES = [
   'assigned',
   'in_progress',
   'completed',
+  'delivery_confirmed',
   'approved',
   'general',
 ] as const;

--- a/Backend/src/routes/ngoRoutes.ts
+++ b/Backend/src/routes/ngoRoutes.ts
@@ -10,6 +10,7 @@ import {
   addVolunteer,
   updateFoodStatus,
   deleteClaimedFood,
+  confirmDelivery,
   getNgoNotifications,
   markNgoNotificationRead,
 } from '../controllers/ngoController';
@@ -35,6 +36,7 @@ router.put('/volunteers/:id', ngoOnly, validateBody(volunteerSchema), updateVolu
 router.post('/volunteers', ngoOnly, validateBody(volunteerSchema), addVolunteer);
 router.patch('/food/:id/status', ngoOnly, validateBody(updateFoodStatusSchema), updateFoodStatus);
 router.delete('/claimed-food/:id', ngoOnly, deleteClaimedFood);
+router.patch('/food/:id/confirm-delivery', ngoOnly, confirmDelivery);
 router.get('/notifications', ngoOnly, getNgoNotifications);
 router.patch('/notifications/:notificationId/read', ngoOnly, markNgoNotificationRead);
 

--- a/Backend/src/routes/volunteerRoutes.ts
+++ b/Backend/src/routes/volunteerRoutes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import multer from 'multer';
 import {
   getVolunteerStats,
   getVolunteerTasks,
@@ -13,9 +14,14 @@ import { updateFoodStatusSchema } from '../validators/schemas';
 const router = Router();
 const volunteerOnly = authMiddleware(['volunteer']);
 
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
+
 router.get('/stats', volunteerOnly, getVolunteerStats);
 router.get('/tasks', volunteerOnly, getVolunteerTasks);
-router.patch('/tasks/:taskId/status', volunteerOnly, validateBody(updateFoodStatusSchema), updateTaskStatus);
+router.patch('/tasks/:taskId/status', volunteerOnly, upload.single('proof_img'), validateBody(updateFoodStatusSchema), updateTaskStatus);
 router.get('/notifications', volunteerOnly, getVolunteerNotifications);
 router.patch('/notifications/:notificationId/read', volunteerOnly, markVolunteerNotificationRead);
 

--- a/Frontend/src/components/dashboard/NGODashboard.tsx
+++ b/Frontend/src/components/dashboard/NGODashboard.tsx
@@ -13,7 +13,9 @@ import {
   Filter,
   DollarSign,
   Eye,
-  Bell, 
+  Bell,
+  ShieldCheck,
+  Image,
 } from "lucide-react";
 import toast, { Toaster } from "react-hot-toast";
 import { StatCard, NotificationBell, StatusBadge } from "../ui";
@@ -66,7 +68,10 @@ interface Food {
   pickup_window_end: string;
   dietary_info: string;
   img: string;
-  status: "Pending" | "Completed" | "assigned";
+  delivery_proof_img?: string;
+  ngo_confirmed?: boolean;
+  ngo_confirmed_at?: string;
+  status: "Pending" | "Completed" | "assigned" | "completed" | "in_progress";
   contact_number: string;
   acceptance_time: string;
   donorId: { name: string; email: string };
@@ -98,6 +103,7 @@ const NGODashboard = () => {
     addVolunteer,
     updateFoodStatus,
     deleteClaimedFood,
+    confirmDelivery,
     notifications,
     getNotifications,
     markNotificationAsRead,
@@ -335,6 +341,21 @@ const NGODashboard = () => {
           boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
         },
       });
+    }
+  };
+
+  const handleConfirmDelivery = async (foodId: string) => {
+    try {
+      await confirmDelivery(foodId);
+      toast.success("Delivery confirmed! Donor and volunteer have been notified.", {
+        duration: 3000,
+        position: "top-right",
+      });
+      setError(null);
+    } catch (err: any) {
+      const msg = err.response?.data?.message || "Failed to confirm delivery";
+      setError(msg);
+      toast.error(msg, { duration: 3000, position: "top-right" });
     }
   };
 
@@ -839,6 +860,34 @@ const NGODashboard = () => {
                       Assign
                     </button>
                   </div>
+                  {/* Proof of delivery & confirm */}
+                  {selectedFood.delivery_proof_img && (
+                    <div>
+                      <p className="flex items-center gap-1 text-sm font-medium text-gray-700 mb-1">
+                        <Image className="h-4 w-4" /> Delivery proof
+                      </p>
+                      <a href={selectedFood.delivery_proof_img} target="_blank" rel="noopener noreferrer">
+                        <img src={selectedFood.delivery_proof_img} alt="delivery proof" className="h-32 w-full rounded-lg object-cover border" />
+                      </a>
+                    </div>
+                  )}
+                  {(selectedFood.status === 'completed' || selectedFood.status === 'Completed') && !selectedFood.ngo_confirmed && (
+                    <button
+                      onClick={() => {
+                        handleConfirmDelivery(selectedFood._id);
+                        setIsModalOpen(false);
+                      }}
+                      className="mt-2 w-full flex items-center justify-center gap-2 bg-emerald-600 text-white py-2 rounded-lg hover:bg-emerald-500 transition font-semibold"
+                    >
+                      <ShieldCheck className="h-4 w-4" /> Confirm Delivery
+                    </button>
+                  )}
+                  {selectedFood.ngo_confirmed && (
+                    <div className="flex items-center gap-2 mt-2 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-700 font-medium">
+                      <ShieldCheck className="h-4 w-4" />
+                      Delivery confirmed {selectedFood.ngo_confirmed_at ? `on ${new Date(selectedFood.ngo_confirmed_at).toLocaleDateString()}` : ''}
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/Frontend/src/components/dashboard/VolunteerDashboard.tsx
+++ b/Frontend/src/components/dashboard/VolunteerDashboard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useVolunteerContext } from '@/contexts/volunteerContext';
-import { Package2, Route, CheckCircle, Star, X } from 'lucide-react';
+import { Package2, Route, CheckCircle, Star, X, Upload, Camera } from 'lucide-react';
 import toast, { Toaster } from 'react-hot-toast';
 import { StatCard, StatusBadge, DataTable, NotificationBell, Button, type Column } from '../ui';
 import { useRealtimeNotifications } from '@/hooks/useRealtimeNotifications';
@@ -88,9 +88,9 @@ const VolunteerDashboard = () => {
     }
   };
 
-  const handleUpdateTaskStatus = async (taskId: string, newStatus: Task['status']) => {
+  const handleUpdateTaskStatus = async (taskId: string, newStatus: Task['status'], proofFile?: File) => {
     try {
-      await updateTaskStatus(taskId, newStatus);
+      await updateTaskStatus(taskId, newStatus, proofFile);
       toast.success(`Task marked ${newStatus.replace('_', ' ')}`);
       setSelectedTask(null);
       setShowStatusModal(false);
@@ -230,7 +230,7 @@ const VolunteerDashboard = () => {
             setShowStatusModal(false);
             setSelectedTask(null);
           }}
-          onSelect={(status) => handleUpdateTaskStatus(selectedTask._id, status)}
+          onSelect={(status, proofFile) => handleUpdateTaskStatus(selectedTask._id, status, proofFile)}
         />
       )}
     </div>
@@ -246,36 +246,71 @@ const StatusModal = ({
   task: Task;
   updating: boolean;
   onClose: () => void;
-  onSelect: (status: Task['status']) => void;
-}) => (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-    <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
-      <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-gray-900">Update status</h3>
-        <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
-          <X className="h-5 w-5" />
-        </button>
-      </div>
-      <p className="mb-4 text-sm text-gray-500">{task.title}</p>
-      <div className="space-y-2">
-        {(['in_progress', 'completed'] as const).map((status) => (
-          <button
-            key={status}
-            onClick={() => onSelect(status)}
-            disabled={updating || task.status === status}
-            className={`w-full rounded-xl px-4 py-2.5 text-left text-sm font-medium transition ${
-              task.status === status
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-50 text-gray-700 hover:bg-gray-100 disabled:opacity-50'
-            }`}
-          >
-            Mark as {status.replace('_', ' ')}
+  onSelect: (status: Task['status'], proofFile?: File) => void;
+}) => {
+  const [proofFile, setProofFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setProofFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Update status</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="h-5 w-5" />
           </button>
-        ))}
+        </div>
+        <p className="mb-4 text-sm text-gray-500">{task.title}</p>
+
+        {/* Proof of delivery upload — shown when completing */}
+        {task.status === 'in_progress' && (
+          <div className="mb-4">
+            <p className="mb-2 text-xs font-medium text-gray-600 flex items-center gap-1">
+              <Camera className="h-3.5 w-3.5" /> Proof photo (optional — shown when marking complete)
+            </p>
+            <button
+              type="button"
+              onClick={() => fileRef.current?.click()}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 p-3 text-sm text-gray-500 hover:border-green-400 hover:text-green-600 transition"
+            >
+              <Upload className="h-4 w-4" />
+              {proofFile ? proofFile.name : 'Upload delivery proof'}
+            </button>
+            <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleFileChange} />
+            {previewUrl && (
+              <img src={previewUrl} alt="proof preview" className="mt-2 h-24 w-full rounded-lg object-cover" />
+            )}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {(['in_progress', 'completed'] as const).map((status) => (
+            <button
+              key={status}
+              onClick={() => onSelect(status, status === 'completed' ? (proofFile ?? undefined) : undefined)}
+              disabled={updating || task.status === status}
+              className={`w-full rounded-xl px-4 py-2.5 text-left text-sm font-medium transition ${
+                task.status === status
+                  ? 'bg-green-600 text-white'
+                  : 'bg-gray-50 text-gray-700 hover:bg-gray-100 disabled:opacity-50'
+              }`}
+            >
+              Mark as {status.replace('_', ' ')}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 const FeedbackCard = ({ task }: { task: Task }) => (
   <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">

--- a/Frontend/src/components/ui/notificationMeta.tsx
+++ b/Frontend/src/components/ui/notificationMeta.tsx
@@ -1,4 +1,4 @@
-import { Bell, Package, HandHeart, Truck, CheckCircle2, UserCheck, type LucideIcon } from 'lucide-react';
+import { Bell, Package, HandHeart, Truck, CheckCircle2, UserCheck, ShieldCheck, type LucideIcon } from 'lucide-react';
 
 export interface NotificationMeta {
   icon: LucideIcon;
@@ -24,6 +24,8 @@ export function getNotificationMeta(type?: string): NotificationMeta {
       return { icon: Truck, chip: 'bg-violet-50 text-violet-600', label: 'In progress' };
     case 'completed':
       return { icon: CheckCircle2, chip: 'bg-green-50 text-green-600', label: 'Completed' };
+    case 'delivery_confirmed':
+      return { icon: ShieldCheck, chip: 'bg-emerald-50 text-emerald-600', label: 'Delivery confirmed' };
     case 'approved':
       return { icon: UserCheck, chip: 'bg-green-50 text-green-600', label: 'Approved' };
     default:

--- a/Frontend/src/contexts/ngoContext.tsx
+++ b/Frontend/src/contexts/ngoContext.tsx
@@ -55,6 +55,7 @@ interface NGOContextType {
   addVolunteer: (data: { name: string; email: string; contact_number: string }) => Promise<void>;
   updateFoodStatus: (foodId: string, status: string) => Promise<void>;
   deleteClaimedFood: (foodId: string) => Promise<void>;
+  confirmDelivery: (foodId: string) => Promise<void>;
   getNotifications: () => Promise<void>;
   markNotificationAsRead: (notificationId: string) => Promise<void>;
 }
@@ -189,6 +190,11 @@ export function NGOProvider({ children }: { children: React.ReactNode }) {
     await getClaimedFoods();
   };
 
+  const confirmDelivery = async (foodId: string) => {
+    await api.patch(`/ngo/food/${foodId}/confirm-delivery`);
+    await getClaimedFoods();
+  };
+
   return (
     <NGOContext.Provider
       value={{
@@ -205,6 +211,7 @@ export function NGOProvider({ children }: { children: React.ReactNode }) {
         addVolunteer,
         updateFoodStatus,
         deleteClaimedFood,
+        confirmDelivery,
         getNotifications,
         markNotificationAsRead,
       }}

--- a/Frontend/src/contexts/volunteerContext.tsx
+++ b/Frontend/src/contexts/volunteerContext.tsx
@@ -40,7 +40,7 @@ interface VolunteerContextType {
   error: string | null;
   getVolunteerStats: (silent?: boolean) => Promise<void>;
   getVolunteerTasks: (silent?: boolean) => Promise<void>;
-  updateTaskStatus: (taskId: string, status: Task["status"]) => Promise<void>;
+  updateTaskStatus: (taskId: string, status: Task["status"], proofFile?: File) => Promise<void>;
   getNotifications: (silent?: boolean) => Promise<void>;
   markNotificationAsRead: (notificationId: string) => Promise<void>;
 }
@@ -200,16 +200,24 @@ export function VolunteerProvider({ children }: { children: React.ReactNode }) {
     }
   }, [hasInitialData.notifications]);
 
-  const updateTaskStatus = useCallback(async (taskId: string, status: Task["status"]) => {
+  const updateTaskStatus = useCallback(async (taskId: string, status: Task["status"], proofFile?: File) => {
     if (requestInProgress.current.updating) return;
     requestInProgress.current.updating = true;
     setLoading((prev) => ({ ...prev, updating: true }));
     setError(null);
 
     try {
-      await api.patch(`/volunteer/tasks/${taskId}/status`, { status });
+      if (status === 'completed' && proofFile) {
+        const formData = new FormData();
+        formData.append('status', status);
+        formData.append('proof_img', proofFile);
+        await api.patch(`/volunteer/tasks/${taskId}/status`, formData, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        });
+      } else {
+        await api.patch(`/volunteer/tasks/${taskId}/status`, { status });
+      }
 
-      // Refresh tasks silently after update
       await getVolunteerTasks(true);
       await getVolunteerStats(true);
     } catch (error: any) {


### PR DESCRIPTION
Volunteers can upload a delivery proof photo when marking a task complete. NGOs see the photo in the food detail modal and can confirm delivery, triggering notifications to both donor and volunteer.

- Food model: delivery_proof_img, ngo_confirmed, ngo_confirmed_at fields
- Notification type: delivery_confirmed added
- Volunteer route: multer upload on status PATCH; controller uploads to ImgBB
- NGO route/controller: PATCH /ngo/food/:id/confirm-delivery
- volunteerContext: updateTaskStatus sends FormData when proofFile present
- ngoContext: confirmDelivery added
- VolunteerDashboard StatusModal: optional proof photo upload for 'completed'
- NGODashboard: proof image preview + Confirm Delivery button in detail modal
- notificationMeta: delivery_confirmed icon + color